### PR TITLE
Add debugging for a known crash.

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -743,20 +743,16 @@ module.exports = function(botkit, config) {
                             // This (better?) solution is similar to https://github.com/howdyai/botkit/pull/769/files
                             if (message.actions) {
                               try {
-                                  message.text = message.actions[0].selected_options[0].value;
                                   const controlType = message.actions[0].type;
                                   if (controlType == 'select') {
-                                      // A dropdown ('select') list provides the *value* in the selected options list
-                                      // but not the text the user selected. This search tries to find it and set it
-                                      // as the name of the action.
-                                      let selectedOption = 'dunno'; // placeholder in case we don't find it
-                                      const options = message.original_message.attachments[0].options;
-                                      for (var opt_idx = 0; opt_idx < options.length; opt_idx++) {
-                                          if (options[opt_idx].value == message.text) {
-                                              selectedOption = options[opt_idx].text;
-                                          }
-                                      }
-                                      message.name = selectedOption;
+                                      // For a dropdown ('select') list we only get the "value" of the user's selection,
+                                      // not the text they selected. So we'll expect the "value" to be of the form
+                                      // "value__text" and split out the two portions into 'text' and 'name'.
+                                      // (we assume "__" is only found once)
+                                      const raw_value = message.actions[0].selected_options[0].value;
+                                      const valueAndText = raw_value.split("__");
+                                      message.text = parseInt(valueAndText[0]);
+                                      message.name = valueAndText[1];
                                   }
                               } catch(e) {
                                   message.text = 'ERROR GETTING VALUE FROM SELECT';

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -737,7 +737,6 @@ module.exports = function(botkit, config) {
                             message.text = message.text.trim();
                         } else {
                             botkit.debug('botkit will crash due to missing message.text: '+JSON.stringify(message)+'.');
-                            console.log(`console.log (to maybe flush output buffer)`)
                             message.text = 'MISSING message.text for "'+JSON.stringify(message)+'".';
                             
                             // This (better?) solution is similar to https://github.com/howdyai/botkit/pull/769/files
@@ -751,7 +750,7 @@ module.exports = function(botkit, config) {
                                       // (we assume "__" is only found once)
                                       const raw_value = message.actions[0].selected_options[0].value;
                                       const valueAndText = raw_value.split("__");
-                                      message.text = parseInt(valueAndText[0]);
+                                      message.text = valueAndText[0];
                                       message.name = valueAndText[1];
                                   }
                               } catch(e) {
@@ -759,8 +758,9 @@ module.exports = function(botkit, config) {
                                   message.name = `EXCEPTION: ${e}.`;
                               }
 
-                              console.log(`message.text: ${message.text}.`);
-                              console.log(`message.name: ${message.name}.`);
+                              botkit.debug(`message.text: ${message.text}.`);
+                              botkit.debug(`message.name: ${message.name}.`);
+                              console.log(`console.log (to maybe flush output buffer)`)
                             }
                         }
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -761,6 +761,8 @@ module.exports = function(botkit, config) {
 
                               botkit.debug(`message.text: ${message.text}.`);
                               botkit.debug(`message.name: ${message.name}.`);
+                              message.original_message.attachments[0].text = `:lion_face: You selected *${message.name}*`;
+                              botkit.debug(`updated message: ${JSON.stringify(message)}.`);
                               console.log(`console.log (to maybe flush output buffer)`)
                             }
                         }

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -737,8 +737,17 @@ module.exports = function(botkit, config) {
                             message.text = message.text.trim();
                         } else {
                             botkit.debug('botkit will crash due to missing message.text: '+JSON.stringify(message)+'.');
-                            console.log(`WTH am I not seeing this? botkit will crash due to missing message.text: ${JSON.stringify(message)}.`)
+                            console.log(`console.log (to maybe flush output buffer)`)
                             message.text = 'MISSING message.text for "'+JSON.stringify(message)+'".';
+                            
+                            // This (better?) solution is similar to https://github.com/howdyai/botkit/pull/769/files
+                            if (message.actions) {
+                              try {
+                                  message.text = message.actions[0].selected_options[0].value;
+                              } catch(e) {
+                                  message.text = 'ERROR GETTING VALUE FROM SELECT';
+                              }
+                            }
                         }
 
                         var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -747,6 +747,7 @@ module.exports = function(botkit, config) {
                               } catch(e) {
                                   message.text = 'ERROR GETTING VALUE FROM SELECT';
                               }
+                              console.log(`message.text: ${message.text}.`);
                             }
                         }
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -736,7 +736,9 @@ module.exports = function(botkit, config) {
                         if (message.text) {
                             message.text = message.text.trim();
                         } else {
-                            console.log(`botkit will crash due to missing message.text: ${JSON.stringify(message)}.`)
+                            botkit.debug('botkit will crash due to missing message.text: '+JSON.stringify(message)+'.');
+                            console.log(`WTH am I not seeing this? botkit will crash due to missing message.text: ${JSON.stringify(message)}.`)
+                            message.text = 'MISSING message.text for "'+JSON.stringify(message)+'".';
                         }
 
                         var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -752,6 +752,7 @@ module.exports = function(botkit, config) {
                                       const valueAndText = raw_value.split("__");
                                       message.text = valueAndText[0];
                                       message.name = valueAndText[1];
+                                      message.actions[0].name = valueAndText[1]; // Force it to show up in the UI
                                   }
                               } catch(e) {
                                   message.text = 'ERROR GETTING VALUE FROM SELECT';

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -744,10 +744,27 @@ module.exports = function(botkit, config) {
                             if (message.actions) {
                               try {
                                   message.text = message.actions[0].selected_options[0].value;
+                                  const controlType = message.actions[0].type;
+                                  if (controlType == 'select') {
+                                      // A dropdown ('select') list provides the *value* in the selected options list
+                                      // but not the text the user selected. This search tries to find it and set it
+                                      // as the name of the action.
+                                      let selectedOption = 'dunno'; // placeholder in case we don't find it
+                                      const options = message.original_message.attachments[0].options;
+                                      for (var opt_idx = 0; opt_idx < options.length; opt_idx++) {
+                                          if (options[opt_idx].value == message.text) {
+                                              selectedOption = options[opt_idx].text;
+                                          }
+                                      }
+                                      message.name = selectedOption;
+                                  }
                               } catch(e) {
                                   message.text = 'ERROR GETTING VALUE FROM SELECT';
+                                  message.name = `EXCEPTION: ${e}.`;
                               }
+
                               console.log(`message.text: ${message.text}.`);
+                              console.log(`message.name: ${message.name}.`);
                             }
                         }
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -735,6 +735,8 @@ module.exports = function(botkit, config) {
 
                         if (message.text) {
                             message.text = message.text.trim();
+                        } else {
+                            console.log(`botkit will crash due to missing message.text: ${JSON.stringify(message)}.`)
                         }
 
                         var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');


### PR DESCRIPTION
`message.text.replace` fails because `message.text` is undefined.